### PR TITLE
Add JSON REST API (v1) with OpenAPI spec and Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,72 @@ Alle Einstellungen werden über eine `.env`-Datei gesteuert (siehe `.env.example
 
 ---
 
+## REST JSON API
+
+Die Anwendung stellt eine vollständige REST API unter `/api/v1/` bereit.
+
+### Interaktive Dokumentation (Swagger UI)
+
+```
+http://localhost:5000/api/docs
+```
+
+Die Swagger UI zeigt alle Endpunkte, Schemata und erlaubt direktes Ausprobieren im Browser.
+
+### Authentifizierung
+
+HTTP Basic Auth – dieselben Zugangsdaten wie die Web-Oberfläche.
+
+```bash
+curl -u team_login:team2025 http://localhost:5000/api/v1/devices
+```
+
+### Endpunktübersicht
+
+| Methode  | Pfad                              | Beschreibung                        | Admin? |
+|----------|-----------------------------------|-------------------------------------|--------|
+| `GET`    | `/api/v1/devices`                 | Alle Geräte (Filter: `?status=`)   | –      |
+| `POST`   | `/api/v1/devices`                 | Gerät anlegen                       | ✓      |
+| `GET`    | `/api/v1/devices/{id}`            | Einzelnes Gerät                     | –      |
+| `PATCH`  | `/api/v1/devices/{id}`            | Gerät aktualisieren                 | ✓      |
+| `DELETE` | `/api/v1/devices/{id}`            | Gerät löschen                       | ✓      |
+| `GET`    | `/api/v1/devices/{id}/qr`         | QR-Code PNG herunterladen           | ✓      |
+| `GET`    | `/api/v1/defects`                 | Defekte (Filter: status, event, …)  | –      |
+| `POST`   | `/api/v1/defects`                 | Defekt melden                       | –      |
+| `GET`    | `/api/v1/defects/{id}`            | Einzelner Defekt                    | –      |
+| `PATCH`  | `/api/v1/defects/{id}/resolve`    | Defekt als behoben markieren        | ✓      |
+| `GET`    | `/api/v1/events`                  | Alle Events auflisten               | –      |
+| `GET`    | `/api/v1/events/{project_number}` | Defekte eines Events                | –      |
+
+### Beispiele
+
+**Defekt melden:**
+```bash
+curl -u team_login:team2025 -X POST http://localhost:5000/api/v1/defects \
+  -H "Content-Type: application/json" \
+  -d '{
+    "device_id": "CAM-001",
+    "category": "Gehäuseschaden",
+    "description": "Linker Griff gebrochen",
+    "event_name": "Sommerfestival 2025",
+    "project_number": "PRJ-2025-042"
+  }'
+```
+
+**Defekte eines Events abrufen:**
+```bash
+curl -u admin:admin123 http://localhost:5000/api/v1/events/PRJ-2025-042
+```
+
+**Defekt als behoben markieren:**
+```bash
+curl -u admin:admin123 -X PATCH http://localhost:5000/api/v1/defects/42/resolve \
+  -H "Content-Type: application/json" \
+  -d '{"resolution_notes": "Griff ersetzt und getestet."}'
+```
+
+---
+
 ## FileMaker-Integration
 
 Der Client in `filemaker.py` spricht die **FileMaker Data API v2**.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,394 @@
+"""
+Redline REST JSON API – v1
+
+Base path : /api/v1
+Auth      : HTTP Basic Auth (same credentials as the web UI)
+Format    : application/json
+
+Endpoints
+---------
+GET    /api/v1/devices                     List devices
+POST   /api/v1/devices                     Create device          [admin]
+GET    /api/v1/devices/<device_id>         Get device
+PATCH  /api/v1/devices/<device_id>         Update device          [admin]
+DELETE /api/v1/devices/<device_id>         Delete device          [admin]
+GET    /api/v1/devices/<device_id>/qr      QR-code PNG            [admin]
+
+GET    /api/v1/defects                     List defects (filterable)
+POST   /api/v1/defects                     Report a defect
+GET    /api/v1/defects/<id>                Get defect
+PATCH  /api/v1/defects/<id>/resolve        Mark defect resolved   [admin]
+
+GET    /api/v1/events                      List distinct events
+GET    /api/v1/events/<project_number>     Defects for one event
+"""
+
+import io
+import functools
+from datetime import datetime, timezone
+
+import qrcode
+from flask import Blueprint, jsonify, request, send_file
+from werkzeug.security import check_password_hash
+
+from models import Defect, Device, User, db
+
+api_bp = Blueprint("api", __name__, url_prefix="/api/v1")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _json_error(message: str, status: int):
+    return jsonify({"error": message}), status
+
+
+def _require_auth(admin_only: bool = False):
+    """Decorator factory – enforces HTTP Basic Auth."""
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            auth = request.authorization
+            if not auth:
+                return _json_error("Authentication required.", 401)
+            user = User.query.filter_by(username=auth.username).first()
+            if not user or not user.check_password(auth.password):
+                return _json_error("Invalid credentials.", 401)
+            if admin_only and not user.is_admin:
+                return _json_error("Admin access required.", 403)
+            # Attach user to request context for downstream use
+            request._api_user = user
+            return f(*args, **kwargs)
+        return wrapped
+    return decorator
+
+
+def _device_to_dict(device: Device) -> dict:
+    return {
+        "device_id": device.device_id,
+        "name": device.name,
+        "description": device.description,
+        "status": device.status,
+        "open_defect_count": device.open_defect_count,
+        "created_at": device.created_at.isoformat(),
+    }
+
+
+def _defect_to_dict(defect: Defect) -> dict:
+    return {
+        "id": defect.id,
+        "device_id": defect.device.device_id,
+        "device_name": defect.device.name,
+        "category": defect.category,
+        "description": defect.description,
+        "event_name": defect.event_name,
+        "project_number": defect.project_number,
+        "status": defect.status,
+        "reporter": defect.reporter,
+        "created_at": defect.created_at.isoformat(),
+        "resolved_at": defect.resolved_at.isoformat() if defect.resolved_at else None,
+        "resolution_notes": defect.resolution_notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Device endpoints
+# ---------------------------------------------------------------------------
+
+@api_bp.route("/devices", methods=["GET"])
+@_require_auth()
+def list_devices():
+    """List all devices, optionally filtered by status."""
+    status = request.args.get("status")
+    query = Device.query
+    if status:
+        query = query.filter_by(status=status)
+    devices = query.order_by(Device.name).all()
+    return jsonify([_device_to_dict(d) for d in devices])
+
+
+@api_bp.route("/devices", methods=["POST"])
+@_require_auth(admin_only=True)
+def create_device():
+    """Create a new device. Requires admin."""
+    data = request.get_json(silent=True) or {}
+    device_id = str(data.get("device_id", "")).strip()
+    name = str(data.get("name", "")).strip()
+    description = str(data.get("description", "")).strip()
+
+    if not device_id or not name:
+        return _json_error("'device_id' and 'name' are required.", 400)
+    if Device.query.filter_by(device_id=device_id).first():
+        return _json_error(f"device_id '{device_id}' already exists.", 409)
+
+    device = Device(device_id=device_id, name=name, description=description)
+    db.session.add(device)
+    db.session.commit()
+    return jsonify(_device_to_dict(device)), 201
+
+
+@api_bp.route("/devices/<string:device_id>", methods=["GET"])
+@_require_auth()
+def get_device(device_id: str):
+    """Get a single device by its device_id."""
+    device = Device.query.filter_by(device_id=device_id).first()
+    if not device:
+        return _json_error(f"Device '{device_id}' not found.", 404)
+    return jsonify(_device_to_dict(device))
+
+
+@api_bp.route("/devices/<string:device_id>", methods=["PATCH"])
+@_require_auth(admin_only=True)
+def update_device(device_id: str):
+    """Update device name, description or status. Requires admin."""
+    device = Device.query.filter_by(device_id=device_id).first()
+    if not device:
+        return _json_error(f"Device '{device_id}' not found.", 404)
+
+    data = request.get_json(silent=True) or {}
+    allowed_statuses = {"Verfügbar", "Wartung"}
+
+    if "name" in data:
+        device.name = str(data["name"]).strip() or device.name
+    if "description" in data:
+        device.description = str(data["description"]).strip()
+    if "status" in data:
+        if data["status"] not in allowed_statuses:
+            return _json_error(f"'status' must be one of: {sorted(allowed_statuses)}", 400)
+        device.status = data["status"]
+
+    db.session.commit()
+    return jsonify(_device_to_dict(device))
+
+
+@api_bp.route("/devices/<string:device_id>", methods=["DELETE"])
+@_require_auth(admin_only=True)
+def delete_device(device_id: str):
+    """Delete a device and all its defects. Requires admin."""
+    device = Device.query.filter_by(device_id=device_id).first()
+    if not device:
+        return _json_error(f"Device '{device_id}' not found.", 404)
+    db.session.delete(device)
+    db.session.commit()
+    return "", 204
+
+
+@api_bp.route("/devices/<string:device_id>/qr", methods=["GET"])
+@_require_auth(admin_only=True)
+def device_qr(device_id: str):
+    """Return the QR-code PNG for a device. Requires admin."""
+    from flask import current_app
+    device = Device.query.filter_by(device_id=device_id).first()
+    if not device:
+        return _json_error(f"Device '{device_id}' not found.", 404)
+
+    report_url = f"{current_app.config['APP_BASE_URL']}/report/{device_id}"
+    img = qrcode.make(report_url)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return send_file(buf, mimetype="image/png",
+                     download_name=f"qr_{device_id}.png")
+
+
+# ---------------------------------------------------------------------------
+# Defect endpoints
+# ---------------------------------------------------------------------------
+
+@api_bp.route("/defects", methods=["GET"])
+@_require_auth()
+def list_defects():
+    """
+    List defects.  Optional query filters:
+      status         – "Offen" | "Behoben"
+      device_id      – device_id string
+      event_name     – partial match
+      project_number – partial match
+      page           – page number (default 1)
+      per_page       – results per page (default 50, max 200)
+    """
+    status = request.args.get("status")
+    device_id_filter = request.args.get("device_id")
+    event_name = request.args.get("event_name")
+    project_number = request.args.get("project_number")
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 50, type=int), 200)
+
+    query = Defect.query
+    if status:
+        query = query.filter_by(status=status)
+    if device_id_filter:
+        device = Device.query.filter_by(device_id=device_id_filter).first()
+        if device:
+            query = query.filter_by(device_id=device.id)
+        else:
+            return jsonify({"items": [], "total": 0, "page": page, "per_page": per_page, "pages": 0})
+    if event_name:
+        query = query.filter(Defect.event_name.ilike(f"%{event_name}%"))
+    if project_number:
+        query = query.filter(Defect.project_number.ilike(f"%{project_number}%"))
+
+    pagination = query.order_by(Defect.created_at.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+    return jsonify({
+        "items": [_defect_to_dict(d) for d in pagination.items],
+        "total": pagination.total,
+        "page": pagination.page,
+        "per_page": per_page,
+        "pages": pagination.pages,
+    })
+
+
+@api_bp.route("/defects", methods=["POST"])
+@_require_auth()
+def create_defect():
+    """
+    Report a new defect for a device.
+    Sets the device status to 'Wartung', syncs to FileMaker,
+    and sends an email notification to the workshop.
+    """
+    from flask import current_app
+    from notifications import send_defect_notification
+
+    data = request.get_json(silent=True) or {}
+    device_id = str(data.get("device_id", "")).strip()
+    category = str(data.get("category", "")).strip()
+    description = str(data.get("description", "")).strip()
+    event_name = str(data.get("event_name", "")).strip()
+    project_number = str(data.get("project_number", "")).strip()
+
+    errors = {}
+    if not device_id:
+        errors["device_id"] = "Required."
+    if not category:
+        errors["category"] = "Required."
+    elif category not in current_app.config["DEFECT_CATEGORIES"]:
+        errors["category"] = f"Must be one of: {current_app.config['DEFECT_CATEGORIES']}"
+    if not description:
+        errors["description"] = "Required."
+    if not event_name:
+        errors["event_name"] = "Required."
+    if not project_number:
+        errors["project_number"] = "Required."
+    if errors:
+        return jsonify({"error": "Validation failed.", "fields": errors}), 400
+
+    device = Device.query.filter_by(device_id=device_id).first()
+    if not device:
+        return _json_error(f"Device '{device_id}' not found.", 404)
+
+    defect = Defect(
+        device_id=device.id,
+        category=category,
+        description=description,
+        event_name=event_name,
+        project_number=project_number,
+        reporter=request._api_user.username,
+    )
+    db.session.add(defect)
+    device.status = "Wartung"
+    db.session.commit()
+
+    # FileMaker sync
+    from filemaker import fm_client
+    fm_client.update_device_status(device.device_id, "Wartung")
+    fm_client.create_defect_record({
+        "Geräte-ID": device.device_id,
+        "Gerätename": device.name,
+        "Kategorie": category,
+        "Beschreibung": description,
+        "Eventname": event_name,
+        "Projektnummer": project_number,
+        "Status": "Offen",
+        "Gemeldet_Von": request._api_user.username,
+    })
+
+    # Email notification
+    mail = current_app.extensions.get("mail")
+    if mail:
+        send_defect_notification(mail, defect, device.name, current_app.config["WORKSHOP_EMAIL"])
+
+    return jsonify(_defect_to_dict(defect)), 201
+
+
+@api_bp.route("/defects/<int:defect_id>", methods=["GET"])
+@_require_auth()
+def get_defect(defect_id: int):
+    """Get a single defect by ID."""
+    defect = db.session.get(Defect, defect_id)
+    if not defect:
+        return _json_error(f"Defect {defect_id} not found.", 404)
+    return jsonify(_defect_to_dict(defect))
+
+
+@api_bp.route("/defects/<int:defect_id>/resolve", methods=["PATCH"])
+@_require_auth(admin_only=True)
+def resolve_defect(defect_id: int):
+    """
+    Mark a defect as resolved.
+    If no open defects remain for the device, its status returns to 'Verfügbar'.
+    Requires admin.
+    """
+    defect = db.session.get(Defect, defect_id)
+    if not defect:
+        return _json_error(f"Defect {defect_id} not found.", 404)
+    if defect.status == "Behoben":
+        return _json_error("Defect is already resolved.", 409)
+
+    data = request.get_json(silent=True) or {}
+    defect.resolution_notes = str(data.get("resolution_notes", "")).strip()
+    defect.status = "Behoben"
+    defect.resolved_at = datetime.now(timezone.utc)
+
+    device = defect.device
+    open_count = Defect.query.filter_by(device_id=device.id, status="Offen").count()
+    if open_count == 0:
+        device.status = "Verfügbar"
+        from filemaker import fm_client
+        fm_client.update_device_status(device.device_id, "Verfügbar")
+
+    db.session.commit()
+    return jsonify(_defect_to_dict(defect))
+
+
+# ---------------------------------------------------------------------------
+# Event endpoints
+# ---------------------------------------------------------------------------
+
+@api_bp.route("/events", methods=["GET"])
+@_require_auth()
+def list_events():
+    """Return all distinct (event_name, project_number) pairs."""
+    rows = (
+        db.session.query(Defect.event_name, Defect.project_number)
+        .distinct()
+        .order_by(Defect.event_name)
+        .all()
+    )
+    return jsonify([
+        {"event_name": r.event_name, "project_number": r.project_number}
+        for r in rows
+    ])
+
+
+@api_bp.route("/events/<string:project_number>", methods=["GET"])
+@_require_auth()
+def get_event_defects(project_number: str):
+    """
+    Return all defects for a given project_number.
+    Optionally filter further with ?event_name=...
+    """
+    event_name = request.args.get("event_name")
+    query = Defect.query.filter_by(project_number=project_number)
+    if event_name:
+        query = query.filter_by(event_name=event_name)
+    defects = query.order_by(Defect.created_at.desc()).all()
+    if not defects:
+        return _json_error(f"No defects found for project '{project_number}'.", 404)
+    return jsonify({
+        "project_number": project_number,
+        "event_name": defects[0].event_name if defects else None,
+        "defect_count": len(defects),
+        "defects": [_defect_to_dict(d) for d in defects],
+    })

--- a/app.py
+++ b/app.py
@@ -411,9 +411,16 @@ def create_app(config_class=Config) -> Flask:
         return render_template("admin/event_report.html", events=events)
 
     # ---- Register blueprints ----
+    from api import api_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(report_bp)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(api_bp)
+
+    # ---- API docs route (Swagger UI) ----
+    @app.route("/api/docs")
+    def api_docs():
+        return render_template("api_docs.html")
 
     # ---- Root route ----
     @app.route("/")

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1,0 +1,639 @@
+openapi: 3.0.3
+
+info:
+  title: Redline Defektmeldesystem API
+  description: |
+    REST JSON API für das QR-Code-basierte Defektmeldesystem von Redline Enterprise.
+
+    ## Authentifizierung
+    Alle Endpunkte verwenden **HTTP Basic Auth** mit denselben Zugangsdaten wie die Web-Oberfläche.
+
+    | Benutzer      | Rolle       | Bemerkung                        |
+    |---------------|-------------|----------------------------------|
+    | `admin`       | Admin       | Vollzugriff                      |
+    | `team_login`  | Standard    | Defekte melden, Daten lesen      |
+
+    ## Statuscodes
+    | Code | Bedeutung                   |
+    |------|-----------------------------|
+    | 200  | OK                          |
+    | 201  | Erstellt                    |
+    | 204  | Gelöscht (kein Body)        |
+    | 400  | Validierungsfehler          |
+    | 401  | Nicht authentifiziert       |
+    | 403  | Keine Berechtigung (Admin)  |
+    | 404  | Nicht gefunden              |
+    | 409  | Konflikt (z.B. ID vergeben) |
+
+  version: "1.0.0"
+  contact:
+    name: Redline Enterprise
+    email: admin@redline.local
+
+servers:
+  - url: /api/v1
+    description: Lokaler Server
+
+security:
+  - basicAuth: []
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+
+  schemas:
+    Device:
+      type: object
+      properties:
+        device_id:
+          type: string
+          example: CAM-001
+        name:
+          type: string
+          example: Kamera Sony A7 IV
+        description:
+          type: string
+          example: Vollformatkamera, Body + 24-70mm
+        status:
+          type: string
+          enum: [Verfügbar, Wartung]
+          example: Verfügbar
+        open_defect_count:
+          type: integer
+          example: 0
+        created_at:
+          type: string
+          format: date-time
+
+    DeviceCreate:
+      type: object
+      required: [device_id, name]
+      properties:
+        device_id:
+          type: string
+          example: CAM-001
+        name:
+          type: string
+          example: Kamera Sony A7 IV
+        description:
+          type: string
+          example: Vollformatkamera, Body + 24-70mm
+
+    DeviceUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: [Verfügbar, Wartung]
+
+    Defect:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 42
+        device_id:
+          type: string
+          example: CAM-001
+        device_name:
+          type: string
+          example: Kamera Sony A7 IV
+        category:
+          type: string
+          example: Gehäuseschaden
+        description:
+          type: string
+          example: Linker Griff gebrochen, Kamera funktioniert noch.
+        event_name:
+          type: string
+          example: Sommerfestival 2025
+        project_number:
+          type: string
+          example: PRJ-2025-042
+        status:
+          type: string
+          enum: [Offen, Behoben]
+        reporter:
+          type: string
+          example: team_login
+        created_at:
+          type: string
+          format: date-time
+        resolved_at:
+          type: string
+          format: date-time
+          nullable: true
+        resolution_notes:
+          type: string
+          nullable: true
+
+    DefectCreate:
+      type: object
+      required: [device_id, category, description, event_name, project_number]
+      properties:
+        device_id:
+          type: string
+          example: CAM-001
+        category:
+          type: string
+          enum:
+            - Mechanischer Schaden
+            - Elektrischer Fehler
+            - Softwareproblem
+            - Gehäuseschaden
+            - Kabelproblem
+            - Displayschaden
+            - Akkuproblem
+            - Wasserschaden
+            - Sonstiges
+          example: Gehäuseschaden
+        description:
+          type: string
+          example: Linker Griff gebrochen, Kamera funktioniert noch.
+          maxLength: 2000
+        event_name:
+          type: string
+          example: Sommerfestival 2025
+          maxLength: 120
+        project_number:
+          type: string
+          example: PRJ-2025-042
+          maxLength: 50
+
+    DefectResolve:
+      type: object
+      properties:
+        resolution_notes:
+          type: string
+          example: Griff ersetzt, getestet – OK.
+
+    DefectListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Defect"
+        total:
+          type: integer
+        page:
+          type: integer
+        per_page:
+          type: integer
+        pages:
+          type: integer
+
+    EventDefectsResponse:
+      type: object
+      properties:
+        project_number:
+          type: string
+        event_name:
+          type: string
+        defect_count:
+          type: integer
+        defects:
+          type: array
+          items:
+            $ref: "#/components/schemas/Defect"
+
+    EventSummary:
+      type: object
+      properties:
+        event_name:
+          type: string
+        project_number:
+          type: string
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+paths:
+
+  # ---- Devices ----
+
+  /devices:
+    get:
+      summary: Alle Geräte auflisten
+      operationId: listDevices
+      tags: [Geräte]
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [Verfügbar, Wartung]
+          description: Geräte nach Status filtern
+      responses:
+        "200":
+          description: Liste aller Geräte
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Device"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      summary: Neues Gerät anlegen
+      operationId: createDevice
+      tags: [Geräte]
+      security:
+        - basicAuth: []   # admin only (enforced in code)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceCreate"
+            example:
+              device_id: CAM-001
+              name: Kamera Sony A7 IV
+              description: Vollformatkamera mit 24-70mm
+      responses:
+        "201":
+          description: Gerät erstellt
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Device"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /devices/{device_id}:
+    parameters:
+      - name: device_id
+        in: path
+        required: true
+        schema:
+          type: string
+        example: CAM-001
+
+    get:
+      summary: Einzelnes Gerät abrufen
+      operationId: getDevice
+      tags: [Geräte]
+      responses:
+        "200":
+          description: Gerät gefunden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Device"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      summary: Gerät aktualisieren
+      operationId: updateDevice
+      tags: [Geräte]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceUpdate"
+      responses:
+        "200":
+          description: Gerät aktualisiert
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Device"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      summary: Gerät löschen
+      operationId: deleteDevice
+      tags: [Geräte]
+      responses:
+        "204":
+          description: Gerät gelöscht
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /devices/{device_id}/qr:
+    parameters:
+      - name: device_id
+        in: path
+        required: true
+        schema:
+          type: string
+        example: CAM-001
+    get:
+      summary: QR-Code PNG herunterladen
+      operationId: getDeviceQr
+      tags: [Geräte]
+      responses:
+        "200":
+          description: PNG-Bild des QR-Codes
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---- Defects ----
+
+  /defects:
+    get:
+      summary: Defekte auflisten
+      operationId: listDefects
+      tags: [Defekte]
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [Offen, Behoben]
+        - name: device_id
+          in: query
+          schema:
+            type: string
+          description: Filtert nach Geräte-ID
+        - name: event_name
+          in: query
+          schema:
+            type: string
+          description: Teilstring-Suche im Eventnamen
+        - name: project_number
+          in: query
+          schema:
+            type: string
+          description: Teilstring-Suche in der Projektnummer
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+      responses:
+        "200":
+          description: Paginierte Defektliste
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefectListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      summary: Neuen Defekt melden
+      operationId: createDefect
+      tags: [Defekte]
+      description: |
+        Meldet einen Defekt für ein Gerät.
+        - Setzt Gerätestatus auf **Wartung**
+        - Synchronisiert mit FileMaker
+        - Sendet E-Mail-Benachrichtigung an die Werkstatt
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DefectCreate"
+            example:
+              device_id: CAM-001
+              category: Gehäuseschaden
+              description: Linker Griff gebrochen
+              event_name: Sommerfestival 2025
+              project_number: PRJ-2025-042
+      responses:
+        "201":
+          description: Defekt gemeldet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Defect"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /defects/{defect_id}:
+    parameters:
+      - name: defect_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 42
+    get:
+      summary: Einzelnen Defekt abrufen
+      operationId: getDefect
+      tags: [Defekte]
+      responses:
+        "200":
+          description: Defekt gefunden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Defect"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /defects/{defect_id}/resolve:
+    parameters:
+      - name: defect_id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 42
+    patch:
+      summary: Defekt als behoben markieren
+      operationId: resolveDefect
+      tags: [Defekte]
+      description: |
+        Setzt den Defektstatus auf **Behoben**.
+        Wenn keine offenen Defekte für das Gerät mehr vorhanden sind,
+        wird der Gerätestatus automatisch auf **Verfügbar** zurückgesetzt.
+        Erfordert Admin-Rechte.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DefectResolve"
+            example:
+              resolution_notes: Griff ersetzt und getestet.
+      responses:
+        "200":
+          description: Defekt behoben
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Defect"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  # ---- Events ----
+
+  /events:
+    get:
+      summary: Alle Events auflisten
+      operationId: listEvents
+      tags: [Events]
+      description: Gibt alle eindeutigen (Eventname, Projektnummer)-Kombinationen zurück.
+      responses:
+        "200":
+          description: Liste der Events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EventSummary"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /events/{project_number}:
+    parameters:
+      - name: project_number
+        in: path
+        required: true
+        schema:
+          type: string
+        example: PRJ-2025-042
+      - name: event_name
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Weiter einschränken nach Eventname
+    get:
+      summary: Defekte eines Events abrufen
+      operationId: getEventDefects
+      tags: [Events]
+      responses:
+        "200":
+          description: Alle Defekte für das Event
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventDefectsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+# ---------------------------------------------------------------------------
+# Shared responses
+# ---------------------------------------------------------------------------
+
+components:
+  responses:
+    Unauthorized:
+      description: Authentifizierung erforderlich
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: Authentication required.
+
+    Forbidden:
+      description: Keine Admin-Berechtigung
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: Admin access required.
+
+    NotFound:
+      description: Ressource nicht gefunden
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: Device 'CAM-999' not found.
+
+    BadRequest:
+      description: Validierungsfehler
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: Validation failed.
+            fields:
+              category: Required.
+
+    Conflict:
+      description: Konflikt (z.B. ID bereits vorhanden)
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: device_id 'CAM-001' already exists.
+
+tags:
+  - name: Geräte
+    description: Geräteverwaltung
+  - name: Defekte
+    description: Defektmeldung und -verwaltung
+  - name: Events
+    description: Event-basierte Auswertung

--- a/templates/api_docs.html
+++ b/templates/api_docs.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Redline API – Dokumentation</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  <style>
+    body { margin: 0; background: #f2f2f7; font-family: -apple-system, sans-serif; }
+    .topbar { background: #cc0000 !important; }
+    .topbar-wrapper img { display: none; }
+    .topbar-wrapper::before {
+      content: "● Redline API";
+      color: #fff;
+      font-size: 20px;
+      font-weight: 700;
+      padding: 0 16px;
+    }
+    .swagger-ui .info .title { color: #cc0000; }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: "/static/openapi.yaml",
+      dom_id: "#swagger-ui",
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+      layout: "BaseLayout",
+      deepLinking: true,
+      displayRequestDuration: true,
+      defaultModelsExpandDepth: 1,
+      defaultModelExpandDepth: 2,
+    });
+  </script>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,7 @@
     <nav class="navbar-nav">
       {% if current_user.is_admin %}
       <a href="{{ url_for('admin.dashboard') }}" class="nav-link {% if request.endpoint and request.endpoint.startswith('admin.') %}active{% endif %}">Admin</a>
+      <a href="{{ url_for('api_docs') }}" class="nav-link {% if request.endpoint == 'api_docs' %}active{% endif %}">API</a>
       {% endif %}
       <span class="nav-user">{{ current_user.username }}</span>
       <a href="{{ url_for('auth.logout') }}" class="nav-link nav-logout">Abmelden</a>


### PR DESCRIPTION
New endpoints under /api/v1/ with HTTP Basic Auth:

Devices
  GET    /api/v1/devices                  – list (filter by status)
  POST   /api/v1/devices                  – create [admin]
  GET    /api/v1/devices/{id}             – get single
  PATCH  /api/v1/devices/{id}             – update [admin]
  DELETE /api/v1/devices/{id}             – delete [admin]
  GET    /api/v1/devices/{id}/qr          – QR PNG [admin]

Defects
  GET    /api/v1/defects                  – list with filters
  POST   /api/v1/defects                  – report (triggers FileMaker + email)
  GET    /api/v1/defects/{id}             – get single
  PATCH  /api/v1/defects/{id}/resolve     – mark resolved [admin]

Events
  GET    /api/v1/events                   – distinct event list
  GET    /api/v1/events/{project_number}  – all defects for an event

Also added:
- static/openapi.yaml – OpenAPI 3.0 specification
- templates/api_docs.html – Swagger UI at /api/docs (CDN)
- API docs link in admin navbar
- REST API section in README with curl examples

https://claude.ai/code/session_01PsSnFFMfAL9PcMbE4kzh6W