### PR TITLE
Move defect categories from config to DB with admin UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ from flask_login import (
 from flask_mail import Mail
 
 from config import Config
-from models import Defect, Device, User, db
+from models import Defect, DefectCategory, Device, User, db
 from filemaker import fm_client
 from notifications import send_defect_notification, send_event_summary_report
 
@@ -107,7 +107,10 @@ def create_app(config_class=Config) -> Flask:
                 message=f"Das Gerät mit der ID '{device_id}' ist im System nicht registriert.",
             ), 404
 
-        categories = app.config["DEFECT_CATEGORIES"]
+        categories = [
+            c.name for c in DefectCategory.query
+            .order_by(DefectCategory.sort_order, DefectCategory.name).all()
+        ]
 
         if request.method == "POST":
             category = request.form.get("category", "").strip()
@@ -410,6 +413,59 @@ def create_app(config_class=Config) -> Flask:
         )
         return render_template("admin/event_report.html", events=events)
 
+    @admin_bp.route("/categories", methods=["GET", "POST"])
+    @admin_required
+    def categories():
+        if request.method == "POST":
+            action = request.form.get("action")
+            if action == "add":
+                name = request.form.get("name", "").strip()
+                if not name:
+                    flash("Name ist erforderlich.", "danger")
+                elif DefectCategory.query.filter_by(name=name).first():
+                    flash(f"Kategorie '{name}' existiert bereits.", "danger")
+                else:
+                    max_order = db.session.query(
+                        db.func.max(DefectCategory.sort_order)
+                    ).scalar() or 0
+                    cat = DefectCategory(name=name, sort_order=max_order + 1)
+                    db.session.add(cat)
+                    db.session.commit()
+                    flash(f"Kategorie '{name}' wurde angelegt.", "success")
+            elif action == "delete":
+                cat_id = request.form.get("cat_id", type=int)
+                cat = db.session.get(DefectCategory, cat_id)
+                if cat:
+                    db.session.delete(cat)
+                    db.session.commit()
+                    flash(f"Kategorie '{cat.name}' wurde gelöscht.", "success")
+            elif action == "move_up":
+                cat_id = request.form.get("cat_id", type=int)
+                _move_category(cat_id, direction="up")
+            elif action == "move_down":
+                cat_id = request.form.get("cat_id", type=int)
+                _move_category(cat_id, direction="down")
+        all_cats = DefectCategory.query.order_by(
+            DefectCategory.sort_order, DefectCategory.name
+        ).all()
+        return render_template("admin/categories.html", categories=all_cats)
+
+    def _move_category(cat_id: int, direction: str) -> None:
+        cats = DefectCategory.query.order_by(
+            DefectCategory.sort_order, DefectCategory.name
+        ).all()
+        idx = next((i for i, c in enumerate(cats) if c.id == cat_id), None)
+        if idx is None:
+            return
+        swap_idx = idx - 1 if direction == "up" else idx + 1
+        if swap_idx < 0 or swap_idx >= len(cats):
+            return
+        cats[idx].sort_order, cats[swap_idx].sort_order = (
+            cats[swap_idx].sort_order,
+            cats[idx].sort_order,
+        )
+        db.session.commit()
+
     # ---- Register blueprints ----
     from api import api_bp
     app.register_blueprint(auth_bp)
@@ -461,6 +517,11 @@ def _seed_db() -> None:
         team.set_password("team2025")  # Change regularly
         db.session.add(team)
         logger.info("Created community user team_login (password: team2025)")
+
+    if DefectCategory.query.count() == 0:
+        for i, name in enumerate(Config.DEFECT_CATEGORIES):
+            db.session.add(DefectCategory(name=name, sort_order=i))
+        logger.info("Seeded default defect categories")
 
     db.session.commit()
 

--- a/models.py
+++ b/models.py
@@ -52,6 +52,18 @@ class Device(db.Model):
         return f"<Device {self.device_id}: {self.name}>"
 
 
+class DefectCategory(db.Model):
+    __tablename__ = "defect_categories"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+    sort_order = db.Column(db.Integer, default=0)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    def __repr__(self) -> str:
+        return f"<DefectCategory {self.name}>"
+
+
 class Defect(db.Model):
     __tablename__ = "defects"
 

--- a/templates/admin/categories.html
+++ b/templates/admin/categories.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+{% block title %}Kategorien{% endblock %}
+
+{% block content %}
+<div class="section-title">Defektkategorien</div>
+
+<!-- Add category -->
+<div class="card">
+  <div class="card-title">Neue Kategorie</div>
+  <div class="card-subtitle">Kategorien erscheinen im Dropdown des Defektmeldeformulars.</div>
+  <form method="POST" action="{{ url_for('admin.categories') }}" novalidate>
+    <input type="hidden" name="action" value="add" />
+    <div style="display:flex;gap:10px;align-items:flex-end;">
+      <div class="form-group" style="flex:1;margin-bottom:0;">
+        <label for="name">Kategoriename</label>
+        <input
+          type="text"
+          id="name"
+          name="name"
+          placeholder="z.B. Optikschaden"
+          maxlength="80"
+          required
+          autocomplete="off"
+        />
+      </div>
+      <button type="submit" class="btn btn-primary">Hinzufügen</button>
+    </div>
+  </form>
+</div>
+
+<!-- Category list -->
+<div class="card">
+  <div class="card-title">Vorhandene Kategorien</div>
+  {% if categories %}
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Name</th>
+          <th style="text-align:right;">Reihenfolge</th>
+          <th style="text-align:right;">Aktionen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for cat in categories %}
+        <tr>
+          <td style="color:var(--gray-400);font-size:13px;">{{ loop.index }}</td>
+          <td><strong>{{ cat.name }}</strong></td>
+          <td style="text-align:right;">
+            <!-- Move up -->
+            {% if not loop.first %}
+            <form method="POST" action="{{ url_for('admin.categories') }}" style="display:inline;">
+              <input type="hidden" name="action" value="move_up" />
+              <input type="hidden" name="cat_id" value="{{ cat.id }}" />
+              <button type="submit" class="btn btn-sm btn-secondary" title="Nach oben">↑</button>
+            </form>
+            {% endif %}
+            <!-- Move down -->
+            {% if not loop.last %}
+            <form method="POST" action="{{ url_for('admin.categories') }}" style="display:inline;">
+              <input type="hidden" name="action" value="move_down" />
+              <input type="hidden" name="cat_id" value="{{ cat.id }}" />
+              <button type="submit" class="btn btn-sm btn-secondary" title="Nach unten">↓</button>
+            </form>
+            {% endif %}
+          </td>
+          <td style="text-align:right;">
+            <form method="POST" action="{{ url_for('admin.categories') }}" style="display:inline;">
+              <input type="hidden" name="action" value="delete" />
+              <input type="hidden" name="cat_id" value="{{ cat.id }}" />
+              <button
+                type="submit"
+                class="btn btn-sm btn-danger"
+                data-confirm="Kategorie '{{ cat.name }}' wirklich löschen?"
+              >Löschen</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p style="color:var(--gray-600);font-size:15px;">
+    Noch keine Kategorien vorhanden. Legen Sie oben die erste Kategorie an.
+  </p>
+  {% endif %}
+</div>
+
+<div class="action-bar">
+  <a href="{{ url_for('admin.dashboard') }}" class="btn btn-secondary">← Zurück zum Dashboard</a>
+</div>
+{% endblock %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -32,6 +32,7 @@
     <a href="{{ url_for('admin.all_defects') }}"  class="btn btn-outline">Alle Defekte</a>
     <a href="{{ url_for('admin.users') }}"         class="btn btn-outline">Benutzerverwaltung</a>
     <a href="{{ url_for('admin.event_report') }}"  class="btn btn-outline">Ereignisberichte</a>
+    <a href="{{ url_for('admin.categories') }}"    class="btn btn-outline">Defektkategorien</a>
   </div>
 </div>
 


### PR DESCRIPTION
- New DefectCategory model (id, name, sort_order, created_at)
- _seed_db() pre-populates categories from Config.DEFECT_CATEGORIES on first startup (no manual migration needed)
- defect_form route now loads categories from DB instead of app.config
- New admin route /admin/categories: add, delete, reorder (↑/↓)
- New template admin/categories.html with table + inline forms
- Dashboard Schnellzugriff: added "Defektkategorien" button

https://claude.ai/code/session_01PsSnFFMfAL9PcMbE4kzh6W