### PR TITLE
fix: add migrate_db.py for missing v0.1b columns

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1141,6 +1141,48 @@ Danach die App normal neu starten – der Seed legt den Default-Disponent-Benutz
 
 ---
 
+### Manuelle Migration: v0.1b – alle neuen Spalten auf einmal (empfohlen)
+
+Ab **v0.1b** wurden folgende Spalten hinzugefügt:
+
+| Tabelle | Spalte | Typ | Standard |
+|---------|--------|-----|---------|
+| `users` | `is_api_user` | BOOLEAN | `0` (False) |
+| `users` | `is_werkstatt` | BOOLEAN | `0` (False) |
+| `devices` | `category_id` | INTEGER (FK) | `NULL` |
+| *(neu)* | `device_categories` | Tabelle | – |
+
+Statt die Spalten einzeln hinzuzufügen, gibt es das Migrations-Script `migrate_db.py` im Projektstamm:
+
+**Windows (PowerShell / Eingabeaufforderung im Projektordner):**
+```powershell
+venv\Scripts\activate
+python migrate_db.py
+```
+
+**Mac / Linux (Terminal im Projektordner):**
+```bash
+source venv/bin/activate
+python migrate_db.py
+```
+
+**Docker Compose:**
+```bash
+docker compose exec redline python migrate_db.py
+```
+
+Das Script prüft jede Spalte einzeln und überspringt bereits vorhandene – es ist sicher mehrfach ausführbar.
+
+**PostgreSQL (manuell):**
+```sql
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_api_user  BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_werkstatt BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE TABLE IF NOT EXISTS device_categories (id SERIAL PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS category_id INTEGER REFERENCES device_categories(id);
+```
+
+---
+
 ## 8. Backup & Restore
 
 ### SQLite (default)

--- a/migrate_db.py
+++ b/migrate_db.py
@@ -1,0 +1,107 @@
+"""
+One-time migration script for existing Redline databases.
+
+Run this once if you are upgrading from a version before v0.1b:
+    python migrate_db.py
+
+Safe to run multiple times – already-existing columns are skipped.
+"""
+
+import sqlite3
+import os
+
+DB_PATH = os.environ.get("DB_PATH", "redline.db")
+
+
+def col_exists(conn, table, column):
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def table_exists(conn, table):
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchall()
+    return len(rows) > 0
+
+
+def run():
+    if not os.path.exists(DB_PATH):
+        print(f"[SKIP] Database '{DB_PATH}' not found – nothing to migrate.")
+        return
+
+    conn = sqlite3.connect(DB_PATH)
+    changes = 0
+
+    # ── users.is_api_user ─────────────────────────────────────────────────────
+    if table_exists(conn, "users") and not col_exists(conn, "users", "is_api_user"):
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN is_api_user BOOLEAN NOT NULL DEFAULT 0"
+        )
+        conn.commit()
+        print("[OK] Added column: users.is_api_user")
+        changes += 1
+    else:
+        print("[SKIP] users.is_api_user already exists")
+
+    # ── users.is_werkstatt ────────────────────────────────────────────────────
+    if table_exists(conn, "users") and not col_exists(conn, "users", "is_werkstatt"):
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN is_werkstatt BOOLEAN NOT NULL DEFAULT 0"
+        )
+        conn.commit()
+        print("[OK] Added column: users.is_werkstatt")
+        changes += 1
+    else:
+        print("[SKIP] users.is_werkstatt already exists")
+
+    # ── users.is_disponent ────────────────────────────────────────────────────
+    if table_exists(conn, "users") and not col_exists(conn, "users", "is_disponent"):
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN is_disponent BOOLEAN NOT NULL DEFAULT 0"
+        )
+        conn.commit()
+        print("[OK] Added column: users.is_disponent")
+        changes += 1
+    else:
+        print("[SKIP] users.is_disponent already exists")
+
+    # ── device_categories table ───────────────────────────────────────────────
+    if not table_exists(conn, "device_categories"):
+        conn.execute(
+            """
+            CREATE TABLE device_categories (
+                id   INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE
+            )
+            """
+        )
+        conn.commit()
+        print("[OK] Created table: device_categories")
+        changes += 1
+    else:
+        print("[SKIP] device_categories already exists")
+
+    # ── devices.category_id ───────────────────────────────────────────────────
+    if table_exists(conn, "devices") and not col_exists(conn, "devices", "category_id"):
+        conn.execute(
+            "ALTER TABLE devices ADD COLUMN category_id INTEGER REFERENCES device_categories(id)"
+        )
+        conn.commit()
+        print("[OK] Added column: devices.category_id")
+        changes += 1
+    else:
+        print("[SKIP] devices.category_id already exists")
+
+    conn.close()
+
+    print()
+    if changes:
+        print(f"Migration complete – {changes} change(s) applied.")
+        print("You can now start the app normally:  python app.py")
+    else:
+        print("Nothing to do – database is already up to date.")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
SQLite databases created before v0.1b are missing:
- users.is_api_user
- users.is_werkstatt
- devices.category_id
- device_categories table

Adds migrate_db.py – idempotent migration script that adds all missing columns/tables without touching existing data. Also documents the migration in docs/INSTALLATION.md (section 7).

https://claude.ai/code/session_01PsSnFFMfAL9PcMbE4kzh6W