### PR TITLE
fix(docker): auto-fix volume ownership + correct Flask-Limiter config…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ FILEMAKER_PASSWORD=your-filemaker-password
 # The public URL where this app is accessible (used for QR code URLs)
 APP_BASE_URL=http://your-server-address:5000
 
+# Rate limiting storage (optional – defaults to in-memory, fine for single instance)
+# Set to Redis URI for multi-instance / persistent rate limits:
+# RATELIMIT_STORAGE_URI=redis://localhost:6379/0
+
 # Service ports (optional – defaults shown)
 APP_PORT=8000
 PROMETHEUS_PORT=9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,13 @@ RUN pip install --no-cache-dir --upgrade pip \
 # ---- Stage 2: runtime image ----
 FROM python:3.11-slim AS runtime
 
-# Security: run as a non-root user with explicit UID/GID 1001.
-# The fixed UID makes Docker named-volume ownership predictable:
-# the host chown command can always use 1001:1001.
-RUN groupadd -r -g 1001 redline \
+# Security: non-root user with fixed UID/GID 1001.
+# Fixed UID makes Docker named-volume ownership predictable.
+# gosu is used by docker-entrypoint.sh to drop from root → redline after
+# fixing volume ownership (see docker-entrypoint.sh for the rationale).
+RUN apt-get update && apt-get install -y --no-install-recommends gosu \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -r -g 1001 redline \
  && useradd -r -u 1001 -g 1001 -d /app -s /sbin/nologin redline
 
 WORKDIR /app
@@ -48,10 +51,14 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Copy application source
 COPY --chown=redline:redline . .
 
+# Copy entrypoint and make it executable (owned by root – intentional)
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Create data directories and set ownership BEFORE the VOLUME declaration.
 # Docker initialises a named volume from the container directory the first time
-# it is mounted.  Without this the directories are root-owned and the app user
-# (redline) cannot write the SQLite database → restart-loop on first deploy.
+# it is mounted.  docker-entrypoint.sh re-applies chown on every start so that
+# pre-existing volumes with wrong ownership are fixed automatically.
 RUN mkdir -p /app/data /app/static/qrcodes \
  && chown -R redline:redline /app/data /app/static/qrcodes
 
@@ -68,21 +75,22 @@ ENV GUNICORN_THREADS=4
 ENV GUNICORN_TIMEOUT=120
 ENV PORT=8000
 
-# Run as non-root
-USER redline
+# NOTE: no USER directive – docker-entrypoint.sh starts as root, fixes
+# volume ownership, then execs gunicorn as the redline user via gosu.
 
 EXPOSE 8000
 
-# Health-check endpoint – just hits the login redirect
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/')" || exit 1
+# Health-check endpoint
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/healthz')" || exit 1
 
-CMD gunicorn \
-    --bind "0.0.0.0:${PORT}" \
-    --workers "${GUNICORN_WORKERS}" \
-    --threads "${GUNICORN_THREADS}" \
-    --timeout "${GUNICORN_TIMEOUT}" \
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh", "-c", "gunicorn \
+    --bind 0.0.0.0:${PORT} \
+    --workers ${GUNICORN_WORKERS} \
+    --threads ${GUNICORN_THREADS} \
+    --timeout ${GUNICORN_TIMEOUT} \
     --access-logfile - \
     --error-logfile - \
     --log-level info \
-    "app:app"
+    app:app"]

--- a/config.py
+++ b/config.py
@@ -91,7 +91,10 @@ class Config:
     #  Rate limiting (flask-limiter)                                       #
     # ------------------------------------------------------------------ #
     RATELIMIT_ENABLED: bool = True
-    RATELIMIT_STORAGE_URL: str = os.environ.get("RATELIMIT_STORAGE_URL", "memory://")
+    # Flask-Limiter 3.x reads RATELIMIT_STORAGE_URI (not _URL).
+    # Defaults to in-memory which is fine for single-instance deployments.
+    # Set RATELIMIT_STORAGE_URI=redis://... in .env to use Redis.
+    RATELIMIT_STORAGE_URI: str = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
     RATELIMIT_DEFAULT: str = "200 per hour;50 per minute"
 
     # ------------------------------------------------------------------ #

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+# Redline – container entrypoint
+#
+# Runs as root so it can fix volume ownership, then drops to the non-root
+# "redline" user (UID/GID 1001) before executing the application.
+#
+# Why this is needed:
+#   Docker only copies directory ownership from the image to a *new* named
+#   volume.  If the volume already exists (e.g. created before a UID change
+#   or on a plain "docker volume create"), it keeps its original ownership
+#   (usually root:root), which prevents the app user from writing the SQLite
+#   database → restart-loop.
+#
+#   Running this fixup on every start costs ~1 ms and is idempotent.
+# ---------------------------------------------------------------------------
+
+set -e
+
+# Fix ownership of writable directories (safe to run as root, no-op if
+# already correct).
+chown -R redline:redline /app/data /app/static/qrcodes
+
+# Drop privileges and exec the CMD (gunicorn …) as the redline user.
+exec gosu redline "$@"


### PR DESCRIPTION
… key

## SQLite restart-loop (unable to open database file) Add docker-entrypoint.sh that runs as root, calls chown -R redline:redline on /app/data and /app/static/qrcodes, then drops to the redline user via gosu before exec-ing gunicorn.

Docker only copies image directory ownership to a named volume on *first* mount. Pre-existing volumes (created before the UID/chown fix was introduced) retain root ownership, causing the non-root app user to fail opening the SQLite DB. The entrypoint fixes this on every container start at near-zero cost and is fully idempotent.

Dockerfile changes:
- Install gosu in runtime stage
- COPY + chmod docker-entrypoint.sh into /usr/local/bin/
- Remove USER directive (entrypoint handles the privilege drop)
- Set ENTRYPOINT ["docker-entrypoint.sh"]
- Healthcheck now hits /healthz (the actual health endpoint)

## Flask-Limiter "in-memory storage" warning
Flask-Limiter 3.x reads RATELIMIT_STORAGE_URI from Flask config. config.py was setting RATELIMIT_STORAGE_URL (wrong key) so Flask-Limiter never found the explicit memory:// value and fell back to the default with a "not recommended for production" warning.

Renamed to RATELIMIT_STORAGE_URI in config.py and documented the Redis upgrade path in .env.example.

https://claude.ai/code/session_01PsSnFFMfAL9PcMbE4kzh6W